### PR TITLE
Add DeepSeek R1-0528 model release news summary (2025-05-29)

### DIFF
--- a/news/2025-05/deepseek-r1-0528-release.md
+++ b/news/2025-05/deepseek-r1-0528-release.md
@@ -1,0 +1,56 @@
+# 📰 DeepSeek Releases Updated R1-0528 Reasoning Model
+
+**Source:** ([reuters.com](https://www.reuters.com/world/china/chinas-deepseek-releases-an-update-its-r1-reasoning-model-2025-05-29/?utm_source=openai))  
+**Date:** May 29, 2025  
+**URL:** [https://www.reuters.com/world/china/chinas-deepseek-releases-an-update-its-r1-reasoning-model-2025-05-29/](https://www.reuters.com/world/china/chinas-deepseek-releases-an-update-its-r1-reasoning-model-2025-05-29/)  
+**Summary:** Chinese AI startup DeepSeek has released an updated version of its R1 reasoning model, named R1-0528, on the Hugging Face platform. This model ranks just below OpenAI's o4 mini and o3 models in code generation benchmarks, while outperforming competitors like xAI’s Grok 3 mini and Alibaba's Qwen 3.
+
+---
+
+### 🔹 What Happened
+
+DeepSeek, a Chinese AI startup, has released an updated version of its R1 reasoning model, named R1-0528, on the Hugging Face platform. This update aims to enhance the model's reasoning and inference capabilities, bringing its performance closer to OpenAI's o3 reasoning models and Google's Gemini 2.5 Pro. ([reuters.com](https://www.reuters.com/world/china/chinas-deepseek-releases-an-update-its-r1-reasoning-model-2025-05-29/?utm_source=openai))
+
+### 🔹 Why It Matters
+
+The release of R1-0528 signifies DeepSeek's continued advancement in AI reasoning models, intensifying competition with U.S. tech giants like OpenAI and Google. By improving the model's performance and reducing the rate of "hallucinations" (false or misleading outputs) by approximately 45-50%, DeepSeek demonstrates its commitment to enhancing AI reliability and applicability across various tasks. ([reuters.com](https://www.reuters.com/world/china/chinas-deepseek-releases-an-update-its-r1-reasoning-model-2025-05-29/?utm_source=openai))
+
+### 🔹 Who's Involved
+
+- **DeepSeek**: A Chinese AI startup based in Hangzhou, known for developing advanced AI models that challenge existing U.S. technologies.
+- **OpenAI**: An American AI research organization, recognized for its GPT series of language models.
+- **Google**: A multinational technology company, developer of the Gemini 2.5 Pro model.
+
+### 🔹 Technical Details
+
+- **Model Name**: R1-0528
+- **Platform**: Hugging Face
+- **Benchmark Performance**:
+  - Ranks just below OpenAI's o4 mini and o3 models in code generation tasks.
+  - Outperforms xAI’s Grok 3 mini and Alibaba's Qwen 3.
+- **Improvements**:
+  - Enhanced reasoning and inference capabilities.
+  - Reduced hallucination rate by approximately 45-50% in tasks like rewriting and summarizing.
+  - Improved performance in generating creative content such as essays and novels.
+  - Enhanced capabilities in generating front-end code and role-playing scenarios.
+
+### 📊 Benchmark Results
+
+| Benchmark       | Score                                      | Dataset/Task |
+|-----------------|--------------------------------------------|--------------|
+| Code Generation | Just below OpenAI's o4 mini and o3 models  | LiveCodeBench |
+| Code Generation | Outperforms xAI’s Grok 3 mini and Alibaba's Qwen 3 | LiveCodeBench |
+
+### 🔗 References
+
+- [DeepSeek Releases Updated R1-0528 Reasoning Model](https://www.reuters.com/world/china/chinas-deepseek-releases-an-update-its-r1-reasoning-model-2025-05-29/)
+
+---
+
+**Step-by-step:**
+
+1. **Search for More Information**: Conducted a web search to gather additional details about DeepSeek's R1-0528 model, including its performance benchmarks and technical specifications.
+2. **Write the Markdown Report**: Compiled the gathered information into a structured markdown report, highlighting the key aspects of the R1-0528 model release.
+3. **Check Link Validity**: Ensured that all external links in the report are valid and accessible.
+4. **Generate Markdown File Name**: Created a concise markdown file name: "deepseek-r1-0528-release.md".
+5. **Return the File Name and Content**: Provided the markdown file name and its content as requested. 


### PR DESCRIPTION
This PR adds a summary news markdown for DeepSeek's R1-0528 reasoning model release (2025-05-29), including model details, benchmarks, and significance as reported by Reuters.

- File: news/2025-05/deepseek-r1-0528-release.md
- Branch: feature/deepseek-r1-0528-release