### PR TITLE
Add Meta Llama 4 release news summary markdown

### DIFF
--- a/news/2025-04/meta-llama4-release.md
+++ b/news/2025-04/meta-llama4-release.md
@@ -1,0 +1,41 @@
+# Meta Releases New AI Model Llama 4
+
+**Source:** Reuters  
+**Date:** April 5, 2025  
+**URL:** [https://www.reuters.com/technology/meta-releases-new-ai-model-llama-4-2025-04-05/](https://www.reuters.com/technology/meta-releases-new-ai-model-llama-4-2025-04-05/)
+
+---
+
+Meta Platforms introduced new versions of its advanced multimodal large language model, Llama 4 Scout and Maverick, capable of processing text, video, images, and audio. The models are among Meta's most advanced and will be open-sourced. Meta also previewed Llama 4 Behemoth, intended to assist in training future models. The release reflects Meta's significant investment and competitive push in AI.
+
+## What Happened
+
+Meta Platforms unveiled the latest iterations of its large language model, Llama 4, introducing Llama 4 Scout and Llama 4 Maverick. These models are designed to process and integrate various data types, including text, video, images, and audio, marking a significant advancement in Meta's AI capabilities. Additionally, Meta previewed Llama 4 Behemoth, a model intended to serve as a foundational tool for training future AI models. The company emphasized that these models are among its most advanced and will be available as open-source software.
+
+## Why It Matters
+
+The release of Llama 4 underscores Meta's commitment to advancing artificial intelligence and its competitive stance in the AI industry. By open-sourcing these models, Meta aims to foster innovation and collaboration within the developer community, potentially setting new standards for AI development. The introduction of Llama 4 Behemoth also indicates Meta's strategic focus on creating robust models to support the next generation of AI applications.
+
+## Who's Involved
+
+- Meta Platforms Inc.: The company responsible for developing and releasing the Llama 4 models.
+- Mark Zuckerberg: CEO of Meta, who has been instrumental in driving the company's AI initiatives.
+- AI Development Community: Developers and researchers who will have access to the open-source Llama 4 models for further innovation.
+
+## Technical Details
+
+- Llama 4 Scout: A 17-billion parameter model with 16 experts, capable of processing a context window of 10 million tokens.
+- Llama 4 Maverick: Also a 17-billion parameter model but with 128 experts, handling a context window of 1 million tokens.
+- Llama 4 Behemoth: A forthcoming model with 288 billion active parameters and 16 experts, designed to assist in training future models.
+- Training Data: The models were trained on a combination of publicly available data, licensed data, and Meta's proprietary data, including content from platforms like Instagram and Facebook.
+
+## Benchmark Results
+
+Specific benchmark results for Llama 4 models have not been publicly disclosed as of now.
+
+## References
+
+- [Meta releases new AI model Llama 4](https://www.reuters.com/technology/meta-releases-new-ai-model-llama-4-2025-04-05/)
+- [Meta's Llama 4 model is running behind schedule, but we might see it soon](https://www.androidcentral.com/apps-software/meta/meta-llama-4-model-delays-internal-problems-report)
+- [Meta introduces Llama application programming interface to attract AI developers](https://www.reuters.com/business/meta-introduces-llama-application-programming-interface-attract-ai-developers-2025-04-29/)
+- [Llama (language model)](https://en.wikipedia.org/wiki/Llama_(language_model))


### PR DESCRIPTION
This PR adds a new news summary markdown file for the Meta Llama 4 release dated April 5, 2025, under the path news/2025-04/meta-llama4-release.md.