### PR TITLE
Add news article about Apple MLX machine learning framework, 2025-02-14

### DIFF
--- a/news/2025-02/apple-mlx-machine-learning-framework.md
+++ b/news/2025-02/apple-mlx-machine-learning-framework.md
@@ -1,0 +1,56 @@
+---
+## 
+Apple Launches MLX: A Machine Learning Framework Optimized for Apple Silicon
+
+**Source:** mlinsider.com  
+**Date:** 2025-02-14  
+**URL:** [https://mlinsider.com/?utm_source=openai](https://mlinsider.com/?utm_source=openai)  
+**Summary:** Apple introduced MLX, an open-source machine learning framework optimized for Apple Silicon processors, simplifying training and deployment of machine learning models on Apple's hardware with enhanced efficiency.
+
+---
+
+### 
+
+
+🔹 What Happened  
+Apple's machine learning research team released MLX, an open-source framework designed specifically for Apple Silicon processors. MLX aims to streamline the training and deployment of machine learning models on Apple's hardware, offering enhanced efficiency and performance.
+
+### 
+
+
+🔹 Why It Matters  
+MLX provides developers with a robust and efficient tool tailored for Apple's hardware, potentially accelerating the development of machine learning applications on Mac, iPhone, and iPad devices. Its open-source nature encourages community collaboration and innovation, fostering a more vibrant ecosystem for machine learning on Apple platforms.
+
+### 
+
+
+🔹 Who's Involved  
+- **Apple's Machine Learning Research Team**: Developed and released MLX to enhance machine learning capabilities on Apple Silicon.
+
+### 
+
+
+
+🔹 Technical Details  
+- **Unified Memory Model:** Arrays reside in shared memory allowing operation on CPU or GPU without data transfer overhead.  
+- **API Support:** Python, Swift, C, and C++ APIs that mirror familiar libraries like NumPy and PyTorch.  
+- **Composable Function Transformations:** Supports automatic differentiation, vectorization, and computation graph optimization.  
+- **Lazy Computation:** Arrays are only materialized when necessary to optimize resource use.  
+- **Dynamic Graphs:** Computation graphs are dynamically built, enabling flexible and efficient model construction.  
+- **Multi-Device Support:** Works across CPU and GPU devices seamlessly.
+
+### 
+
+
+🔗 References  
+- [MLX Open Source Project - Apple](https://opensource.apple.com/projects/mlx/)  
+- [GitHub Repository for MLX](https://github.com/ml-explore/mlx)  
+- [Apple Launches MLX - ComputerWorld](https://www.computerworld.com/article/1611155/apple-launches-mlx-machine-learning-framework-for-apple-silicon.html)  
+- [Apple Silicon & MLX - InfoQ](https://www.infoq.com/news/2023/12/apple-silicon-machine-learning/)  
+- [MLX Framework on Apple Silicon - 9to5Mac](https://9to5mac.com/2023/12/06/mlx-machine-learning-apple-silicon-mac/)  
+- [Apple MLX Framework Overview - Gadgets360](https://www.gadgets360.com/laptops/news/apple-silicon-mlx-framework-open-source-efficient-machine-learning-4645755)  
+- [Apple Foundation Models & MLX - The Verge](https://www.theverge.com/2023/12/6/23990678/apple-foundation-models-generative-ai-mlx)  
+- [Running LLMs Llama 3 on Apple Silicon with MLX - Medium](https://medium.com/@manuelescobar-dev/running-large-language-models-llama-3-on-apple-silicon-with-apples-mlx-framework-4f4ee6e15f31)  
+- [Introduction to MLX: Apples Machine Learning Framework - Medium](https://medium.com/lolml/introduction-to-mlx-apples-machine-learning-framework-527b81f23fa5)  
+
+---


### PR DESCRIPTION
This PR adds a markdown news article summarizing Apple's launch of the MLX machine learning framework optimized for Apple Silicon processors.