### PR TITLE
Add news article summary for o3-mini release June 2025

### DIFF
--- a/news/2025-06/o3-mini-release.md
+++ b/news/2025-06/o3-mini-release.md
@@ -1,0 +1,46 @@
+## 📰 OpenAI Releases o3-mini Model on Microsoft Azure
+
+**Source:** InfoQ  
+**Date:** 2025-06-12  
+**URL:** [https://www.infoq.com/MachineLearning/news/?utm_source=openai](https://www.infoq.com/MachineLearning/news/?utm_source=openai)  
+**Summary:** OpenAI has launched the advanced o3-mini model via Microsoft Azure, enhancing AI applications with improved cost efficiency, faster performance, and adjustable reasoning capabilities. Designed for complex tasks, it supports structured outputs and backward compatibility, empowering developers to drive innovation across various industries.
+
+---
+
+### 🔹 What Happened
+
+OpenAI has introduced the o3-mini model through Microsoft Azure, aiming to enhance AI applications with improved cost efficiency, faster performance, and adjustable reasoning capabilities. This model is designed to handle complex tasks, supporting structured outputs and backward compatibility, thereby empowering developers to drive innovation across various industries.
+
+### 🔹 Why It Matters
+
+The release of o3-mini signifies a strategic advancement in AI model development, offering enhanced reasoning capabilities at a more cost-effective rate compared to its predecessor, o1-mini. This move is particularly significant in the context of increasing competition in the AI industry, especially following the release of DeepSeek's R1 model, which intensified the AI race between the U.S. and China.  ([axios.com](https://www.axios.com/2025/01/31/o3-mini-chatgpt-release-openai?utm_source=openai))
+
+### 🔹 Who's Involved
+
+- **OpenAI:** The organization responsible for developing and releasing the o3-mini model.
+- **Microsoft:** Partnering with OpenAI to make the o3-mini model available through the Azure OpenAI Service.
+
+### 🔹 Technical Details
+
+- **Model:** o3-mini
+- **Release Date:** January 31, 2025
+- **Key Features:**
+  - **Reasoning Effort Control:** Allows users to adjust the model’s cognitive load with low, medium, and high reasoning levels, providing greater control over response and latency. ([devblogs.microsoft.com](https://devblogs.microsoft.com/semantic-kernel/using-openais-o3-mini-reasoning-model-in-semantic-kernel/?utm_source=openai))
+  - **Structured Outputs:** Supports JSON Schema constraints, making it easier to generate well-defined, structured outputs for automated workflows. ([devblogs.microsoft.com](https://devblogs.microsoft.com/semantic-kernel/using-openais-o3-mini-reasoning-model-in-semantic-kernel/?utm_source=openai))
+  - **Functions and Tools Support:** Seamlessly integrates with functions and external tools, ideal for AI-powered automation. ([devblogs.microsoft.com](https://devblogs.microsoft.com/semantic-kernel/using-openais-o3-mini-reasoning-model-in-semantic-kernel/?utm_source=openai))
+  - **Developer Messages:** The “role”: “developer” attribute replaces the system message in previous models, offering more flexible and structured instruction handling. ([devblogs.microsoft.com](https://devblogs.microsoft.com/semantic-kernel/using-openais-o3-mini-reasoning-model-in-semantic-kernel/?utm_source=openai))
+  - **Continued Strength in Coding, Math, and Scientific Reasoning:** Enhances capabilities in these critical areas, ensuring high performance. ([devblogs.microsoft.com](https://devblogs.microsoft.com/semantic-kernel/using-openais-o3-mini-reasoning-model-in-semantic-kernel/?utm_source=openai))
+
+These features make o3-mini a powerful tool for developers and enterprises looking to optimize their AI applications.
+
+### 🔹 Benchmark Results
+
+Specific benchmark results for the o3-mini model are not provided in the available sources.
+
+### 🔹 References
+
+- [OpenAI releases o3-mini reasoning model following DeepSeek frenzy](https://www.axios.com/2025/01/31/o3-mini-chatgpt-release-openai)
+- [Using OpenAI’s o3-mini Reasoning Model in Semantic Kernel](https://devblogs.microsoft.com/semantic-kernel/using-openais-o3-mini-reasoning-model-in-semantic-kernel/)
+- [OpenAI o3-mini now available on GitHub Copilot and Microsoft Azure](https://www.neowin.net/news/openai-o3-mini-now-available-on-github-copilot-and-microsoft-azure/)
+- [O3-Mini Reasoning Model, now available in Microsoft Azure OpenAI Service](https://techcommunity.microsoft.com/discussions/marketplace-forum/o3-mini-reasoning-model-now-available-in-microsoft-azure-openai-service/4372800)
+- [Microsoft Azure OpenAI Service launches o3-mini model; system offers enhanced reasoning capabilities, structured outputs, and improved cost efficiency compared to o1-mini](https://www.industryintel.com/transformation-and-innovation/news/microsoft-azure-openai-service-launches-o3-mini-model-system-offers-enhanced-reasoning-capabilities-structured-outputs-and-improved-cost-efficiency-compared-to-o1-mini-167967223248) 


### PR DESCRIPTION
This PR adds a news article summary markdown file for the OpenAI o3-mini model release on Microsoft Azure, dated June 2025, under news/2025-06/ directory.