### PR TITLE
Add news article: Bridging AI Governance Research Gaps (2025)

### DIFF
--- a/news/2025-06/bridging-ai-governance-research-gaps-2025.md
+++ b/news/2025-06/bridging-ai-governance-research-gaps-2025.md
@@ -1,0 +1,39 @@
+## 📰 Bridging the Research Gaps on AI Governance: A Systematic Review of Open Questions in the Generative AI Research Corpus
+
+**Source:** arXiv  
+**Date:** June 10, 2025  
+**URL:** https://arxiv.org/abs/2505.00174  
+**Summary:** An analysis of 1,178 AI safety and reliability papers reveals research focus disparities and gaps in deployment areas such as healthcare and misinformation, recommending enhanced data access and observability for governance improvements.
+
+---
+
+### 🔹 What Happened
+
+A recent study titled "Real-World Gaps in AI Governance Research" analyzed 1,178 safety and reliability papers from a total of 9,439 generative AI papers published between January 2020 and March 2025. The research compared outputs from leading AI companies—Anthropic, Google DeepMind, Meta, Microsoft, and OpenAI—and top AI universities, including Carnegie Mellon University, MIT, NYU, Stanford, UC Berkeley, and the University of Washington. The findings indicate a growing concentration of corporate AI research on pre-deployment areas such as model alignment and testing, with diminishing attention to deployment-stage issues like model bias. Significant research gaps were identified in high-risk deployment domains, including healthcare, finance, misinformation, persuasive and addictive features, hallucinations, and copyright. The study emphasizes the need for improved observability into deployed AI systems and recommends expanding external researcher access to deployment data to address these gaps. ([arxiv.org](https://arxiv.org/abs/2505.00174))
+
+### 🔹 Why It Matters
+
+The study highlights critical disparities in AI governance research, particularly the insufficient focus on real-world deployment challenges. By identifying these gaps, the research underscores the necessity for a more balanced approach that includes both pre-deployment and deployment-stage considerations. Addressing these issues is vital for developing AI systems that are not only effective but also ethical and safe in real-world applications.
+
+### 🔹 Who's Involved
+
+- **Ilan Strauss**: Lead author from the AI Disclosures Project, Social Science Research Council.
+- **Isobel Moure**: Co-author from the AI Disclosures Project.
+- **Tim O'Reilly**: Co-author affiliated with O'Reilly Media.
+- **Sruly Rosenblat**: Co-author from the AI Disclosures Project.
+
+### 🔹 Technical Details
+
+- **Data Sources**: 1,178 safety and reliability papers from a subset of 9,439 generative AI papers published between January 2020 and March 2025.
+- **Research Focus**: Comparison of research outputs from leading AI companies and top AI universities.
+- **Key Findings**:
+  - Corporate AI research increasingly focuses on pre-deployment areas like model alignment and testing.
+  - Diminishing attention to deployment-stage issues such as model bias.
+  - Significant research gaps in high-risk deployment domains, including healthcare, finance, misinformation, persuasive and addictive features, hallucinations, and copyright.
+- **Recommendations**:
+  - Expand external researcher access to deployment data.
+  - Enhance systematic observability of in-market AI behaviors.
+
+### 🔗 References
+
+- [Real-World Gaps in AI Governance Research](https://arxiv.org/abs/2505.00174)


### PR DESCRIPTION
This PR adds a news article markdown file for the research paper summary on AI governance research gaps published in 2025.