### PR TITLE
Add news article: Apple introduces MLX machine learning framework for Apple Silicon

### DIFF
--- a/news/2025-06/apple-mlx-machine-learning-framework.md
+++ b/news/2025-06/apple-mlx-machine-learning-framework.md
@@ -1,0 +1,7 @@
+# Apple Introduces MLX: A Machine Learning Framework for Apple Silicon
+
+**Source:** MLInsider  
+**Date:** 2025-06-21  
+**URL:** [https://mlinsider.com/?utm_source=openai](https://mlinsider.com/?utm_source=openai)  
+
+Apple launched MLX, an open-source machine learning framework optimized for Apple Silicon processors, enabling efficient training and deployment of ML models on Apple hardware.


### PR DESCRIPTION
This PR adds a new news article about Apple's launch of MLX, a machine learning framework optimized for Apple Silicon processors.