### PR TITLE
Add summary for US Senate rejection of 10-year ban on state AI regulation

### DIFF
--- a/news/2025-07/us-senate-rejects-10-year-ban-state-ai-regulation.md
+++ b/news/2025-07/us-senate-rejects-10-year-ban-state-ai-regulation.md
@@ -1,0 +1,44 @@
+## U.S. Senate Rejects 10-Year Ban on State-Level AI Regulation
+
+**Source:** AP News  
+**Date:** July 2, 2025  
+**URL:** [https://apnews.com/article/20beeeb6967057be5fe64678f72f6ab0](https://apnews.com/article/20beeeb6967057be5fe64678f72f6ab0) (unavailable)  
+**Summary:** The U.S. Senate voted overwhelmingly to remove a proposed 10-year ban on state-level AI regulation, preserving decentralized oversight and allowing states to continue developing their own AI regulations.
+
+---
+
+### What Happened
+
+On July 1, 2025, the U.S. Senate voted 99-1 to remove a proposed 10-year ban on state-level regulation of artificial intelligence (AI) that was part of a larger bill originally pushed by the Trump administration. The ban would have prevented states from enforcing any AI-related laws for a decade. The amendment to remove the ban was led by Senators Marsha Blackburn (R-TN) and Maria Cantwell (D-WA) with bipartisan support, reflecting concerns by state officials and AI safety advocates about centralized federal control stifling necessary local protections.
+
+### Why It Matters
+
+This decision keeps regulatory power decentralized, allowing states to create and enforce their own AI regulations tailored to their specific needs and concerns, including consumer protection, child safety, and transparency in automated decisions. It reflects the Senates recognition that state governments must have the authority to respond to AI governance issues in a timely and localized manner while comprehensive federal legislation remains absent.
+
+### Who's Involved
+
+- **Senator Marsha Blackburn (R-TN):** Championed the removal of the ban to protect states regulatory rights.  
+- **Senator Maria Cantwell (D-WA):** Supported the bipartisan amendment.  
+- **Governors and Attorneys General:** Across parties, opposed the moratorium citing existing and needed protections at state levels.  
+- **AI Safety Advocates:** Expressed concern that the ban would give AI companies excessive freedom and harm public safety.  
+
+### Technical Details
+
+- The original ban was a 10-year moratorium on state enforcement of AI laws or regulations, effectively consolidating AI regulatory authority at the federal level.  
+- Passed as part of a broader spending and tax bill known as the "One Big Beautiful Bill" championed by former President Trump.  
+- The overturned provision would have withheld federal funding from states that attempted to regulate AI during the moratorium period.
+
+---
+
+### Benchmark Results
+
+No benchmarks or performance metrics were discussed in the sources.
+
+---
+
+### References
+
+- [Senators Reject 10-Year Ban on State-Level AI Regulation](https://time.com/7299044/senators-reject-10-year-ban-on-state-level-ai-regulation-in-blow-to-big-tech/) (Time)  
+- [US Senate overwhelmingly rejects plan to stop states regulating AI](https://www.ft.com/content/77d2de10-b31b-4543-acdf-ff92f9993455) (Financial Times)  
+
+---


### PR DESCRIPTION
This PR adds a news summary for the recent U.S. Senate decision to reject a 10-year ban on state-level AI regulation, preserving decentralized oversight for states.