### PR TITLE
Add news summary: ByteDance surpasses Meta in quarterly revenue for the first time (July 2025)

### DIFF
--- a/news/2025-07/byte-dance-surpasses-meta-quarterly-revenue.md
+++ b/news/2025-07/byte-dance-surpasses-meta-quarterly-revenue.md
@@ -1,0 +1,40 @@
+## 📰 ByteDance Surpasses Meta in Quarterly Revenue for the First Time
+
+**Source:** Reuters  
+**Date:** July 17, 2025  
+**URL:** [https://www.reuters.com/technology/ai-intelligencer-bytedance-surpasses-meta-plus-jensen-huangs-fruitful-trip-2025-07-17/](https://www.reuters.com/technology/ai-intelligencer-bytedance-surpasses-meta-plus-jensen-huangs-fruitful-trip-2025-07-17/)  
+**Summary:** Chinese tech giant ByteDance has outpaced Meta in quarterly revenue, driven by global advertising, marking a significant shift in competitive dynamics within the technology and AI sectors.
+
+---
+
+### 🔹 What Happened
+
+ByteDance, the Chinese parent company of TikTok, reported over $43 billion in revenue for the first quarter of 2025, surpassing Meta's $42.31 billion for the same period. This marks the first time ByteDance has exceeded Meta's quarterly revenue. ([reuters.com](https://www.reuters.com/technology/ai-intelligencer-bytedance-surpasses-meta-plus-jensen-huangs-fruitful-trip-2025-07-17/?utm_source=openai))
+
+### 🔹 Why It Matters
+
+This milestone signifies a major shift in the competitive landscape of the technology and AI sectors, highlighting ByteDance's rapid growth and the increasing influence of Chinese tech companies on the global stage.
+
+### 🔹 Who's Involved
+
+- **ByteDance:** The Chinese tech company behind TikTok, experiencing rapid growth in global advertising revenue.
+- **Meta Platforms, Inc.:** The parent company of Facebook, Instagram, and WhatsApp, facing increased competition from ByteDance.
+
+### 🔹 Technical Details
+
+- **Revenue Figures:** ByteDance's Q1 2025 revenue exceeded $43 billion, while Meta's was $42.31 billion. ([reuters.com](https://www.reuters.com/technology/ai-intelligencer-bytedance-surpasses-meta-plus-jensen-huangs-fruitful-trip-2025-07-17/?utm_source=openai))
+- **Growth Drivers:** Both companies have been investing heavily in artificial intelligence to enhance their platforms and advertising capabilities.
+
+---
+
+### 🔹 Benchmark Results
+
+No specific benchmark results were provided in the source article.
+
+---
+
+### 🔗 References
+
+- [ByteDance Surpasses Meta in Quarterly Revenue](https://www.reuters.com/technology/ai-intelligencer-bytedance-surpasses-meta-plus-jensen-huangs-fruitful-trip-2025-07-17/)
+
+---


### PR DESCRIPTION
This pull request adds a detailed news summary markdown file reporting ByteDance's quarterly revenue surpassing Meta's in 2025, reflecting competitive shifts in the tech and AI sectors.