### PR TITLE
Add news article: Meta launches Superintelligence Labs and recruits top AI talent

### DIFF
--- a/news/2025-07/meta-superintelligence-labs-launch.md
+++ b/news/2025-07/meta-superintelligence-labs-launch.md
@@ -1,0 +1,42 @@
+## 📰 Meta launches Superintelligence Labs and aggressively recruits top AI talent
+
+**Source:** Reuters  
+**Date:** 2025-07-08  
+**URL:** [https://www.reuters.com/business/zuckerbergs-meta-superintelligence-labs-poaches-top-ai-talent-silicon-valley-2025-07-08/](https://www.reuters.com/business/zuckerbergs-meta-superintelligence-labs-poaches-top-ai-talent-silicon-valley-2025-07-08/)  
+**Summary:** Meta's CEO Mark Zuckerberg has launched a new AI division, Meta Superintelligence Labs, and has been aggressively hiring top AI experts from competitors to strengthen its position in AI.
+
+---
+
+### 🔹 What Happened
+
+Meta CEO Mark Zuckerberg has established Meta Superintelligence Labs, a new division focused on advancing artificial intelligence. The company has been actively recruiting leading AI talent from competitors such as OpenAI, Google, Anthropic, and Apple to bolster its AI capabilities. Notable hires include Alexandr Wang, former CEO of Scale AI, and Nat Friedman, former CEO of GitHub, who will co-lead the new team. Other key additions are Daniel Gross from Safe Superintelligence, Ruoming Pang from Apple, and several engineers from OpenAI, including Huiwen Chang, Shuchao Bi, Ji Lin, and Hongyu Ren. 
+
+### 🔹 Why It Matters
+
+This strategic move underscores Meta's commitment to becoming a leader in artificial intelligence. By assembling a team of top-tier AI experts, Meta aims to develop advanced language models and integrated AI systems that can compete with industry leaders like OpenAI and Google. The aggressive recruitment strategy, involving lucrative compensation packages and strategic investments, highlights the company's determination to accelerate its AI initiatives. 
+
+### 🔹 Who's Involved
+
+- **Mark Zuckerberg**: CEO of Meta, spearheading the establishment of Meta Superintelligence Labs and the recruitment of AI talent.
+- **Alexandr Wang**: Former CEO of Scale AI, now serving as Meta's Chief AI Officer and co-leading the new division.
+- **Nat Friedman**: Former CEO of GitHub, co-leading Meta Superintelligence Labs.
+- **Daniel Gross**: Former CEO of Safe Superintelligence, leading Meta's AI products division.
+- **Ruoming Pang**: Former head of Apple's Foundation Models team, joining Meta's Superintelligence Labs.
+- **Huiwen Chang, Shuchao Bi, Ji Lin, Hongyu Ren**: Engineers from OpenAI contributing to Meta's AI development.
+
+### 🔹 Technical Details
+
+- **Meta Superintelligence Labs**: A new division within Meta focused on developing advanced AI systems.
+- **Scale AI**: A data-labeling startup in which Meta invested $14.3 billion for a 49% stake, bringing Alexandr Wang aboard to lead the Superintelligence Labs division.
+- **Safe Superintelligence**: An AI startup co-founded by Daniel Gross, focusing on AI safety and alignment.
+
+### 🔹 Benchmark Results
+
+No specific benchmark results are mentioned in the available sources.
+
+### 🔗 References
+
+- [Meta's Superintelligence push: Zuckerberg bets billions to poach top AI talent — here's the strategy](https://www.fortuneindia.com/technology/metas-superintelligence-push-zuckerberg-bets-billions-to-poach-top-ai-talent-heres-the-strategy/124535/)
+- [Meta's AI Superintelligence Team 2025 | How Zuckerberg Is Winning the Talent War](https://trueblue.co.th/blog/meta-ai-superintelligence-hiring-2025)
+- [Every A.I. Researcher Who Has Joined Meta’s Superintelligence Team](https://observer.com/2025/07/meta-superintellience-team-members/)
+- [How Meta’s Superintelligence Labs is reshaping the AI talent war](https://www.emarketer.com/content/how-meta-s-superintelligence-labs-reshaping-ai-talent-war)


### PR DESCRIPTION
This PR adds a new markdown news article about Meta's launch of Superintelligence Labs and aggressive recruitment of top AI talent in July 2025.