### PR TITLE
Add news article on AWS AgentCore launch - 2025-07

### DIFF
--- a/news/2025-07/aws-agentcore-launch.md
+++ b/news/2025-07/aws-agentcore-launch.md
@@ -1,0 +1,55 @@
+## 📰 Amazon Web Services Launches AgentCore Platform for Creating Custom AI Agents
+
+**Source:** MarketingProfs  
+**Date:** July 18, 2025  
+**URL:** [https://www.marketingprofs.com/opinions/2025/53455/ai-update-july-18-2025-ai-news-and-views-from-the-past-week?utm_source=openai](https://www.marketingprofs.com/opinions/2025/53455/ai-update-july-18-2025-ai-news-and-views-from-the-past-week?utm_source=openai)  
+**Summary:** AWS introduced AgentCore, a platform to build interconnected AI agents capable of data analysis, code generation, and automation with support for multiple AI models and a marketplace for sharing agents.
+
+---
+
+### 🔹 What Happened
+
+At the AWS Summit New York 2025, Amazon Web Services (AWS) unveiled Amazon Bedrock AgentCore, a comprehensive suite of services designed to facilitate the deployment and operation of AI agents at scale. This platform addresses the challenges developers face in moving AI agents from prototype to production by providing purpose-built infrastructure, powerful tools, and essential controls for trustworthy operations. 
+
+### 🔹 Why It Matters
+
+The introduction of AgentCore signifies a pivotal advancement in the AI industry, enabling developers to create and manage AI agents with enhanced security, scalability, and flexibility. By offering a modular and composable suite of services, AWS empowers organizations to build interconnected AI agents capable of complex tasks such as data analysis, code generation, and automation. This development is poised to accelerate the adoption of AI agents across various industries, transforming how software is built and interacts with the world.
+
+### 🔹 Who's Involved
+
+- **Amazon Web Services (AWS):** The cloud computing arm of Amazon, responsible for the development and launch of AgentCore.
+- **Swami Sivasubramanian:** Vice President of AWS Agentic AI, who highlighted the transformative impact of AI agents during the AWS Summit New York 2025.
+
+### 🔹 Technical Details
+
+AgentCore comprises several key components:
+
+- **AgentCore Runtime:** Provides a secure, serverless environment for deploying and scaling AI agents, supporting both real-time interactions and long-running workloads up to 8 hours.
+- **AgentCore Memory:** Enables agents to maintain short-term and long-term memory across interactions, facilitating context-aware decision-making.
+- **AgentCore Identity:** Manages secure access to AWS services and third-party tools, integrating with identity providers like Okta and Microsoft Entra ID.
+- **AgentCore Gateway:** Converts existing APIs and AWS Lambda functions into agent-compatible tools, supporting protocols like Model Context Protocol (MCP).
+- **AgentCore Code Interpreter:** Allows agents to generate and execute code securely in sandboxed environments, enhancing problem-solving capabilities.
+- **AgentCore Browser Tool:** Provides a cloud-based browser runtime for agents to interact with websites at scale, including live viewing for troubleshooting and auditing.
+- **AgentCore Observability:** Offers monitoring, tracing, and debugging features through dashboards powered by Amazon CloudWatch, enabling continuous improvement and rapid issue resolution.
+
+Additionally, AWS introduced AI agents and tools in the AWS Marketplace, allowing customers to discover, purchase, and manage AI agent solutions from third-party providers. This centralized catalog simplifies the procurement and deployment of AI agents, accelerating the adoption of agentic AI across various applications.
+
+---
+
+### 🔹 Benchmark Results
+
+As of now, specific benchmark results for AgentCore have not been publicly released.
+
+---
+
+### 🔹 References
+
+- [Amazon Bedrock AgentCore now available in preview](https://aws.amazon.com/about-aws/whats-new/2025/07/amazon-bedrock-agentcore-preview/)
+- [Introducing Amazon Bedrock AgentCore: Securely deploy and operate AI agents at any scale (preview)](https://aws.amazon.com/blogs/aws/introducing-amazon-bedrock-agentcore-securely-deploy-and-operate-ai-agents-at-any-scale/)
+- [AWS looks to super-charge AI agents with Amazon Bedrock AgentCore](https://www.techradar.com/pro/aws-looks-to-super-charge-ai-agents-with-amazon-bedrock-agentcore)
+- [Amazon Launches Bedrock AgentCore for Enterprise AI Agent Infrastructure](https://www.infoq.com/news/2025/07/amazon-bedrock-agentcore-launch/)
+- [AWS Rolls Out Agentic AI Tools: Transforming Software for the Agentic Era](https://www.linkedin.com/pulse/aws-rolls-out-agentic-ai-tools-transforming-software-era-eminenture-yensc)
+- [AWS launches AgentCore system and agentic marketplace](https://www.techtarget.com/searchenterpriseai/news/366627853/AWS-launches-AgentCore-system-and-agentic-marketplace)
+- [AWS Debuts AgentCore: Scale Enterprise AI Agents Beyond Prototype](https://www.aitechsuite.com/ai-news/aws-debuts-agentcore-scale-enterprise-ai-agents-beyond-prototype)
+- [Amazon Bedrock AgentCore (Preview) - AWS](https://aws.amazon.com/bedrock/agentcore/)
+- [Introducing AI agents and tools in AWS Marketplace](https://aws.amazon.com/about-aws/whats-new/2025/07/ai-agents-tools-aws-marketplace)


### PR DESCRIPTION
This pull request adds a new markdown file with the news article summary about the AWS AgentCore platform launch dated July 18, 2025.