### PR TITLE
Add news article: OpenAI acquires Jony Ive's AI hardware startup io for $6.5 billion

### DIFF
--- a/news/2025-07/openai-acquires-jony-ive-io.md
+++ b/news/2025-07/openai-acquires-jony-ive-io.md
@@ -1,0 +1,38 @@
+## 📰 OpenAI Acquires Jony Ive’s AI Hardware Startup io for $6.5 Billion
+
+**Source:** [Wired](https://www.wired.com/story/jony-ive-open-ai-hardware-io/)  
+**Date:** May 21, 2025  
+**URL:** [https://www.wired.com/story/jony-ive-open-ai-hardware-io/](https://www.wired.com/story/jony-ive-open-ai-hardware-io/)  
+**Summary:** OpenAI has acquired io, an AI hardware startup founded by former Apple designer Jony Ive, in a $6.5 billion all-stock deal. This acquisition marks OpenAI's largest to date and signifies a strategic move into the AI hardware sector.
+
+---
+
+### 🔹 What Happened
+
+OpenAI announced the acquisition of io, an AI hardware startup co-founded by Jony Ive, in a deal valued at approximately $6.5 billion. This acquisition includes $5 billion in equity and consolidates OpenAI's previous 23% stake in io. The merger aims to integrate cutting-edge AI hardware development with innovative design, leveraging Ive's expertise to create new AI-powered devices.
+
+### 🔹 Why It Matters
+
+This acquisition represents OpenAI's strategic push into the consumer hardware market, aiming to develop AI-native devices that go beyond conventional screens and interfaces. By combining OpenAI's AI capabilities with Ive's design expertise, the companies plan to create a new generation of AI-powered devices, potentially redefining user interaction with technology.
+
+### 🔹 Who's Involved
+
+- **OpenAI:** An AI research organization known for developing advanced AI models, including ChatGPT.
+- **Jony Ive:** Former Chief Design Officer at Apple, renowned for designing iconic products like the iPhone and iPad.
+- **io Products:** An AI hardware startup founded by Jony Ive, Scott Cannon, Evans Hankey, and Tang Tan in 2024.
+
+### 🔹 Technical Details
+
+- **Acquisition Details:** OpenAI acquired io in an all-stock deal valued at $6.5 billion, including a $5 billion equity component.
+- **Product Vision:** The collaboration aims to develop AI-native devices that transcend traditional screens and interfaces, potentially including wearables or other AI-powered hardware.
+- **Leadership:** Jony Ive will lead design and creative responsibilities across OpenAI and io, while io's 55 employees will join OpenAI's hardware division.
+
+### 📊 Benchmark Results
+
+*No benchmark results are provided in the available sources.*
+
+### 🔗 References
+
+- [OpenAI's Big Bet That Jony Ive Can Make AI Hardware Work](https://www.wired.com/story/jony-ive-open-ai-hardware-io/)
+
+---


### PR DESCRIPTION
This PR adds a markdown news article summarizing OpenAI's acquisition of Jony Ive's AI hardware startup io for $6.5 billion, highlighting the strategic importance and details of the acquisition.