### PR TITLE
Add news article summary for Google's Gemini CLI (2025-07)

### DIFF
--- a/news/2025-07/google-gemini-cli-ai-developer-terminals.md
+++ b/news/2025-07/google-gemini-cli-ai-developer-terminals.md
@@ -1,0 +1,42 @@
+## 📰 Google's Gemini CLI Brings AI to Developer Terminals
+
+**Source:** ImobiSoft  
+**Date:** 2025-07-30  
+**URL:** [https://imobisoft.co.uk/ai-breakthroughs-july-2025/?utm_source=openai](https://imobisoft.co.uk/ai-breakthroughs-july-2025/?utm_source=openai)  
+**Summary:** Google introduced Gemini CLI, integrating advanced natural language AI (Gemini 2.5 Pro) into developer terminals to streamline coding and debugging tasks.
+
+---
+
+### 🔹 What Happened
+
+Google unveiled Gemini CLI, an open-source command-line interface that brings the capabilities of its Gemini 2.5 Pro AI model directly into developers' terminals. This tool is designed to enhance coding, problem-solving, and task management by providing AI assistance within the terminal environment. ([blog.google](https://blog.google/technology/developers/introducing-gemini-cli-open-source-ai-agent/?utm_source=openai))
+
+### 🔹 Why It Matters
+
+Gemini CLI represents a significant advancement in developer productivity tools by integrating AI directly into the command-line interface. This integration allows developers to perform tasks such as code generation, debugging, and content creation more efficiently, reducing the need to switch between different applications and interfaces. ([blog.google](https://blog.google/technology/developers/introducing-gemini-cli-open-source-ai-agent/?utm_source=openai))
+
+### 🔹 Who's Involved
+
+- **Google:** Developed and released Gemini CLI, aiming to enhance developer workflows through AI integration.
+- **ImobiSoft:** Reported on the release and its implications for the developer community.
+
+### 🔹 Technical Details
+
+- **Model:** Gemini 2.5 Pro, Google's advanced AI model, powers Gemini CLI.
+- **Features:**
+  - **Conversation History:** Allows tracking and referencing previous interactions.
+  - **Configurable Models and Parameters:** Enables switching between different Gemini models and adjusting parameters like temperature.
+  - **File Attachments:** Supports attaching files, including pasted text, directly to prompts.
+  - **System Prompts:** Facilitates setting system-level prompts to guide the model’s behavior throughout a conversation. ([discuss.ai.google.dev](https://discuss.ai.google.dev/t/announcing-gemini-cli-a-command-line-tool-for-the-google-gemini-api/96003?utm_source=openai))
+
+### 🔹 Benchmark Results
+
+As of now, specific benchmark results for Gemini CLI have not been publicly disclosed.
+
+### 🔗 References
+
+- [Announcing `gemini-cli`: A Command-Line Tool for the Google Gemini API](https://discuss.ai.google.dev/t/announcing-gemini-cli-a-command-line-tool-for-the-google-gemini-api/96003)
+- [Google announces Gemini CLI: your open-source AI agent](https://blog.google/technology/developers/introducing-gemini-cli-open-source-ai-agent/)
+- [Google Launches Gemini CLI: Open-Source Terminal AI Agent for Developers](https://www.infoq.com/news/2025/07/google-gemini-cli/)
+
+---  


### PR DESCRIPTION
This pull request adds a new markdown summary for the news article "Google's Gemini CLI Brings AI to Developer Terminals" dated 2025-07-30 by ImobiSoft. The summary is placed in the `news/2025-07/` folder.