### PR TITLE
Add news article: Palo Alto Networks Acquires CyberArk for $25 Billion

### DIFF
--- a/news/2025-07/palo-alto-cyberark-acquisition.md
+++ b/news/2025-07/palo-alto-cyberark-acquisition.md
@@ -1,0 +1,41 @@
+## 📰 Palo Alto Networks Acquires CyberArk for $25 Billion
+
+**Source:** ([ft.com](https://www.ft.com/content/e8e00344-f791-4964-bada-c68de70dbfcf?utm_source=openai))  
+**Date:** July 30, 2025  
+**URL:** [https://www.ft.com/content/e8e00344-f791-4964-bada-c68de70dbfcf](https://www.ft.com/content/e8e00344-f791-4964-bada-c68de70dbfcf)  
+**Summary:** Palo Alto Networks has agreed to acquire Israeli cybersecurity firm CyberArk Software in a $25 billion cash-and-stock deal, marking its largest acquisition to date. This strategic move aims to enhance Palo Alto's identity security capabilities amid increasing AI-driven cyber threats.
+
+---
+
+### 🔹 What Happened
+
+Palo Alto Networks announced a $25 billion acquisition of CyberArk Software, a leader in identity security, including privileged access management. The deal involves CyberArk shareholders receiving $45 in cash and 2.2005 shares of Palo Alto Networks stock per CyberArk share. The transaction is expected to close in the second half of Palo Alto Networks' fiscal 2026, pending regulatory approvals and shareholder consent. ([ft.com](https://www.ft.com/content/e8e00344-f791-4964-bada-c68de70dbfcf?utm_source=openai))
+
+### 🔹 Why It Matters
+
+This acquisition signifies a strategic shift for Palo Alto Networks, enabling it to enter the identity security market, which is becoming increasingly critical due to the rise of AI-driven cyber threats. By integrating CyberArk's solutions, Palo Alto aims to offer a comprehensive cybersecurity suite that addresses both human and machine identities, enhancing its position in a rapidly evolving threat landscape. ([ft.com](https://www.ft.com/content/e8e00344-f791-4964-bada-c68de70dbfcf?utm_source=openai))
+
+### 🔹 Who's Involved
+
+- **Palo Alto Networks**: A leading cybersecurity company known for its network security and firewall technologies.
+- **CyberArk Software**: An Israeli firm specializing in identity security, particularly privileged access management.
+- **Nikesh Arora**: CEO of Palo Alto Networks, who emphasized the strategic importance of this acquisition. ([ft.com](https://www.ft.com/content/e8e00344-f791-4964-bada-c68de70dbfcf?utm_source=openai))
+
+### 🔹 Technical Details
+
+- **Privileged Access Management (PAM)**: CyberArk's core technology that safeguards sensitive systems by controlling and monitoring access to critical accounts.
+- **Identity Security**: The broader field encompassing solutions to protect both human and machine identities, crucial in the era of AI-driven cyber threats. ([ft.com](https://www.ft.com/content/e8e00344-f791-4964-bada-c68de70dbfcf?utm_source=openai))
+
+---
+
+### Benchmark Results
+
+No specific benchmark results were provided in the available sources.
+
+---
+
+### References
+
+- [Palo Alto Networks agrees $25bn takeover of CyberArk](https://www.ft.com/content/e8e00344-f791-4964-bada-c68de70dbfcf)
+- [Palo Alto Networks to buy CyberArk for $25 billion](https://www.cybersecuritydive.com/news/palo-alto-networks-buy-cyberark-25-billion/756393/)
+


### PR DESCRIPTION
This pull request adds a new markdown news article about Palo Alto Networks' acquisition of CyberArk for $25 billion, covering key details, significance, and technical aspects.