### PR TITLE
Add news article: Meta appoints Shengjia Zhao as Chief Scientist for Superintelligence Labs

### DIFF
--- a/news/2025-07/meta-appoints-shengjia-zhao-superintelligence-labs.md
+++ b/news/2025-07/meta-appoints-shengjia-zhao-superintelligence-labs.md
@@ -1,0 +1,43 @@
+## Meta Appoints Shengjia Zhao as Chief Scientist for Superintelligence Labs
+
+**Source:** AI Forum UK  
+**Date:** 2025-07-28  
+**URL:** [https://aiforum.org.uk/ai-news-roundup-july-28-2025/?utm_source=openai](https://aiforum.org.uk/ai-news-roundup-july-28-2025/?utm_source=openai)  
+**Summary:** Meta has appointed Shengjia Zhao, a former GPT-4 co-creator, as Chief Scientist for its Superintelligence Labs, signaling a strong commitment to AI leadership.
+
+---
+
+### What Happened
+
+Meta CEO Mark Zuckerberg announced the appointment of Shengjia Zhao as Chief Scientist of Meta Superintelligence Labs (MSL). Zhao, previously a researcher at OpenAI and co-creator of ChatGPT and GPT-4, will lead cutting-edge research on advanced AI models and architectures alongside Alexandr Wang, Meta's Chief AI Officer and former CEO of Scale AI.
+
+### Why It Matters
+
+This appointment highlights Meta's aggressive investment and ambition to lead in artificial intelligence and artificial general intelligence (AGI). The creation of MSL and recruitment of top AI talent underscore the company's goal to compete with industry leaders like OpenAI and Google.
+
+### Who's Involved
+
+- **Shengjia Zhao**: Former OpenAI researcher and co-creator of ChatGPT and GPT-4; appointed Chief Scientist of MSL.
+- **Mark Zuckerberg**: Meta CEO who announced the appointment and supports AI leadership.
+- **Alexandr Wang**: Meta Chief AI Officer and former Scale AI CEO, working alongside Zhao.
+
+### Technical Details
+
+- **Meta Superintelligence Labs (MSL)**: A new Meta division focused on advanced AI research, aiming to push boundaries in AI capabilities and AGI.
+- **AI Reasoning Model o1**: Developed by Zhao at OpenAI, showcasing his contributions to AI reasoning capabilities.
+- **Llama series**: Meta's advanced AI language models, part of the broader AI research landscape Zhao will help advance.
+
+---
+
+### Benchmark Results
+
+No benchmark results disclosed.
+
+---
+
+### References
+
+- [Meta appoints Shengjia Zhao as chief scientist of AI superintelligence unit - TechCrunch](https://techcrunch.com/2025/07/25/meta-names-shengjia-zhao-as-chief-scientist-of-ai-superintelligence-unit/)
+- [Meta's AI Talent Hunt - Financial Times](https://www.ft.com/content/905179cc-52ee-4cd6-81bd-dfdaa6a8fe88)
+- [AI Forum UK Article (source)](https://aiforum.org.uk/ai-news-roundup-july-28-2025/?utm_source=openai)
+


### PR DESCRIPTION
This pull request adds a new AI news article summary about Meta appointing Shengjia Zhao as Chief Scientist for Superintelligence Labs.