### PR TITLE
Add news article summary for Chai Discovery $70M funding

### DIFF
--- a/news/2025-08/chai-discovery-funding-2025.md
+++ b/news/2025-08/chai-discovery-funding-2025.md
@@ -1,0 +1,40 @@
+## 📰 Chai Discovery Secures $70 Million Funding for AI-Driven Drug Discovery
+
+**Source:** Financial Times  
+**Date:** 2025-08-07  
+**URL:** [https://www.ft.com/content/eeaff7a2-acc8-4a79-a564-80debdcecc1a](https://www.ft.com/content/eeaff7a2-acc8-4a79-a564-80debdcecc1a)  
+**Summary:** Chai Discovery, an AI-driven drug discovery startup backed by OpenAI, has raised $70 million in Series A funding, bringing its valuation to approximately $550 million. The funding round was led by Menlo Ventures, with participation from new investors such as Yosemite and DCVC, as well as existing backers like Thrive Capital, OpenAI, and Dimension. The company aims to revolutionize drug development by using artificial intelligence to design molecules and antibodies that can bind to proteins, including those previously considered "undruggable."  
+
+---
+
+### 🔹 What Happened
+
+Chai Discovery, a San Francisco-based startup specializing in AI-driven drug discovery, has secured $70 million in Series A funding. The funding round was led by Menlo Ventures, including their Anthology Fund—a joint partnership with Anthropic to identify and support promising AI companies—with participation from new investors such as Yosemite, DCVC, and others, as well as existing investors like Thrive Capital, OpenAI, Dimension, Neo, and others.  ([chaidiscovery.com](https://www.chaidiscovery.com/news/series-a-announcement?utm_source=openai))
+
+### 🔹 Why It Matters
+
+The pharmaceutical industry has long faced challenges in developing treatments for certain diseases due to the complexity of targeting specific proteins. Chai Discovery's approach leverages artificial intelligence to design molecules and antibodies that can effectively bind to these proteins, including those previously deemed "undruggable." This innovation has the potential to accelerate drug development processes and lead to breakthroughs in treating a range of diseases.
+
+### 🔹 Who's Involved
+
+- **Chai Discovery**: An AI-driven drug discovery startup co-founded by Joshua Meier, Jack Dent, Matthew McPartlon, and Jacques Boitreaud.
+- **Menlo Ventures**: Led the Series A funding round, including their Anthology Fund.
+- **OpenAI**: An existing investor in Chai Discovery.
+- **Mikael Dolsten, M.D., Ph.D.**: Former Chief Scientific Officer of Pfizer, who is joining Chai Discovery's board of directors.
+
+### 🔹 Technical Details
+
+- **Chai-2 Model**: Chai Discovery's latest AI model, Chai-2, has demonstrated a near 20% hit rate in antibody design. This is a significant improvement over traditional methods, which often require screening millions to billions of antibodies to find effective candidates.  ([chaidiscovery.com](https://www.chaidiscovery.com/news/series-a-announcement?utm_source=openai))
+
+### 📊 Benchmark Results
+
+While specific benchmark results are not provided in the available sources, the Chai-2 model's performance is highlighted as a significant advancement in AI-driven drug discovery.
+
+### 🔗 References
+
+- [Chai Discovery's Series A Announcement](https://www.chaidiscovery.com/news/series-a-announcement)
+- [Chai Discovery's Chai-2 Breakthrough](https://www.chaidiscovery.com/news/chai-discovery-unveils-chai-2-breakthrough-achieving-fully-de-novo-antibody-design-with-ai)
+- [Chai Discovery's Chai-2 Endpoints](https://www.chaidiscovery.com/news/chai-2-endpoints)
+- [Menlo Ventures' Investment in Chai Discovery](https://www.pharmexec.com/view/menlo-ventures-led-70-million-series-a-fundraiser-chai-discovery-transform-molecular-design)
+
+---


### PR DESCRIPTION
This pull request adds a new markdown file with a summary of the news article about Chai Discovery securing $70 million in funding for AI-driven drug discovery.