### PR TITLE
Add news article: Better drugs through AI by Insitro CEO

### DIFF
--- a/news/2024-12/better-drugs-through-ai-insitro-ceo-on-ml-for-big-pharma.md
+++ b/news/2024-12/better-drugs-through-ai-insitro-ceo-on-ml-for-big-pharma.md
@@ -1,0 +1,41 @@
+## Better drugs through AI? Insitro CEO on what machine learning can teach Big Pharma
+
+**Source:** AP News  
+**Date:** 2024-12-02  
+**URL:** [https://apnews.com/article/004c0ce0442b72c37bfec6e032796808](https://apnews.com/article/004c0ce0442b72c37bfec6e032796808)  
+**Summary:** Insitro, a biotechnology company founded in 2018, leverages artificial intelligence (AI) and machine learning (ML) to revolutionize drug discovery. By analyzing extensive biological datasets, Insitro aims to significantly shorten the decade-long development cycle of new medicines and design more effective treatments by understanding complex diseases.
+
+---
+
+### What Happened
+
+Insitro, an AI-driven company founded in 2018, is working to revolutionize the pharmaceutical industry's drug discovery process. By utilizing machine learning to analyze vast datasets of chemical and biological markers, Insitro aims to shorten the decade-long development cycle of new medicines. CEO Daphne Koller highlights the challenge of drug discovery, noting that a better understanding of complex diseases is essential for designing effective interventions. Insitro's approach focuses on identifying new therapeutic hypotheses and targeting specific patient populations. ([apnews.com](https://apnews.com/article/004c0ce0442b72c37bfec6e032796808?utm_source=openai))
+
+### Why It Matters
+
+The traditional drug discovery process is lengthy and costly, often taking over a decade to develop new medications. Insitro's innovative approach promises to expedite this timeline, potentially bringing life-saving drugs to market more quickly and efficiently. By harnessing AI and ML, Insitro addresses the challenge of understanding complex diseases, which is crucial for designing effective interventions. ([apnews.com](https://apnews.com/article/004c0ce0442b72c37bfec6e032796808?utm_source=openai))
+
+### Who's Involved
+
+- **Insitro**: A biotechnology company specializing in AI-driven drug discovery.
+- **Daphne Koller**: CEO and founder of Insitro, with a background in computer science and machine learning.
+- **Eli Lilly and Bristol Myers Squibb**: Major pharmaceutical companies collaborating with Insitro to develop treatments for various diseases. ([apnews.com](https://apnews.com/article/004c0ce0442b72c37bfec6e032796808?utm_source=openai))
+
+### Technical Details
+
+- **Machine Learning Models**: Insitro employs advanced machine learning algorithms to analyze large-scale biological data, identifying patterns and relationships that inform drug discovery.
+- **High-Throughput Biology**: The company integrates high-throughput biological data generation with machine learning to create predictive models for disease and therapeutic interventions. ([insitro.com](https://www.insitro.com/platform/?utm_source=openai))
+- **Collaborative Platforms**: Insitro has developed platforms that accelerate multiple steps in the research and development value chain, aiming to bring better drugs to patients faster. ([insitro.com](https://www.insitro.com/platform/?utm_source=openai))
+
+### Benchmark Results
+
+While specific benchmark results are not provided in the available sources, Insitro's collaborations with major pharmaceutical companies and the achievement of discovery milestones indicate the effectiveness of their AI-driven approach.
+
+### References
+
+- [Better drugs through AI? Insitro CEO on what machine learning can teach Big Pharma](https://apnews.com/article/004c0ce0442b72c37bfec6e032796808)
+- [Insitro and Lilly Enter Strategic Agreements to Advance Novel Treatments for Metabolic Diseases](https://www.biospace.com/press-releases/insitro-and-lilly-enter-strategic-agreements-to-advance-novel-treatments-for-metabolic-diseases)
+- [Transforming Drug Discovery Using Artificial Intelligence](https://www.insitro.com/news/transforming-drug-discovery-using-artificial-intelligence/)
+- [Our Platform for Machine Learning to Unravel Biology](https://www.insitro.com/platform/)
+
+---  


### PR DESCRIPTION
This PR adds a markdown file with a summary of the news article titled 'Better drugs through AI? Insitro CEO on what machine learning can teach Big Pharma' from AP News. The article discusses how Insitro leverages AI and machine learning to accelerate drug discovery and shorten development timelines, aiming to design better medicines by understanding complex diseases.