### PR TITLE
Add summary for MIT study on low ROI of AI investments

### DIFF
--- a/news/2025-08/mit-study-low-roi-ai-investments.md
+++ b/news/2025-08/mit-study-low-roi-ai-investments.md
@@ -1,0 +1,42 @@
+## MIT Study Reveals Low ROI on AI Investments
+
+**Source:** ([axios.com](https://www.axios.com/2025/08/21/ai-wall-street-big-tech?utm_source=openai))  
+**Date:** August 21, 2025  
+**URL:** [https://www.axios.com/2025/08/21/ai-wall-street-big-tech](https://www.axios.com/2025/08/21/ai-wall-street-big-tech)  
+**Summary:** A recent MIT study analyzing 300 public AI projects found that 95% of organizations received no financial return on their AI investments. The research indicates companies acquiring proven AI tools are more successful than those developing AI internally, challenging current AI investment practices and urging a reevaluation of AI strategies.
+
+---
+
+### What Happened
+
+MIT researchers examined 300 public AI initiatives and discovered that 95% of organizations did not achieve a financial return on their AI investments. The study also found that companies purchasing AI tools were more successful than those developing them internally. ([axios.com](https://www.axios.com/2025/08/21/ai-wall-street-big-tech?utm_source=openai))
+
+### Why It Matters
+
+This finding raises concerns about the effectiveness of current AI investment strategies, especially given the significant capital expenditures by major tech companies. The study suggests that organizations may need to reassess their approaches to AI adoption to achieve better financial outcomes. ([axios.com](https://www.axios.com/2025/08/21/ai-wall-street-big-tech?utm_source=openai))
+
+### Who's Involved
+
+- MIT Researchers: Conducted the study analyzing 300 public AI projects.
+- Aditya Challapally: Research contributor to project NANDA at MIT.
+- Steve Sosnick: Chief strategist at Interactive Brokers, commented on the study's implications.
+
+### Technical Details
+
+- Study Focus: Analysis of 300 public AI initiatives.
+- Key Findings: 95% of organizations did not achieve a financial return on their AI investments.
+- Comparison: Companies that purchased AI tools were more successful than those that developed them internally.
+
+---
+
+### Benchmark Results
+
+The study did not provide specific benchmark results or scores.
+
+---
+
+### References
+
+- [MIT Study on AI Profits Rattles Tech Investors](https://www.axios.com/2025/08/21/ai-wall-street-big-tech)
+
+---  


### PR DESCRIPTION
This PR adds a detailed markdown summary of the recent MIT study revealing the low financial return on AI investments. The summary is added to the news directory in the appropriate year-month subfolder.