### PR TITLE
Add AI-driven vaccine research news from Oracle's £118M grant to Oxford

### DIFF
--- a/news/2025-08/oracle-oxford-ai-vaccine-research.md
+++ b/news/2025-08/oracle-oxford-ai-vaccine-research.md
@@ -1,0 +1,46 @@
+## 📰 Oracle's £118 Million Grant to Oxford for AI-Driven Vaccine Research
+
+**Source:** Financial Times  
+**Date:** 2025-08-30  
+**URL:** [https://www.ft.com/content/e21af386-2171-4d2d-a4a6-9d52761261ff](https://www.ft.com/content/e21af386-2171-4d2d-a4a6-9d52761261ff)  
+**Summary:** Larry Ellison's Ellison Institute of Technology donated £118 million to Oxford University to advance an AI-driven vaccine research project targeting antibiotic-resistant pathogens. The funding supports human challenge trials and analysis of large biological datasets to identify effective immune responses, aiming to combat antimicrobial resistance projected to cause millions of deaths globally.
+
+---
+
+### 🔹 What Happened
+
+Larry Ellison's Ellison Institute of Technology has donated £118 million to Oxford University's Vaccine Group to fund a five-year AI-driven vaccine research project. The initiative, led by Professor Sir Andrew Pollard and Professor Daniela Ferreira, will utilize human challenge trials to study immune responses to antibiotic-resistant bacteria such as E. coli, Streptococcus pneumoniae, and Staphylococcus aureus. The project aims to develop vaccines by analyzing extensive biological datasets, including blood and tissue samples, to identify effective immune responses. ([ft.com](https://www.ft.com/content/e21af386-2171-4d2d-a4a6-9d52761261ff?utm_source=openai))
+
+### 🔹 Why It Matters
+
+This substantial grant is one of the largest Oxford has ever received and underscores the critical role of AI in advancing vaccine research. The project addresses the growing global threat of antimicrobial resistance, which is projected to cause 39 million deaths over the next 25 years. By leveraging AI to analyze complex biological data, the initiative seeks to accelerate the development of vaccines against pathogens that have been challenging to target with traditional methods. ([ft.com](https://www.ft.com/content/e21af386-2171-4d2d-a4a6-9d52761261ff?utm_source=openai))
+
+### 🔹 Who's Involved
+
+- **Ellison Institute of Technology**: Founded by Oracle co-founder Larry Ellison, the institute is funding the project to advance AI-driven solutions for global health challenges.
+
+- **Oxford University Vaccine Group**: Led by Professor Sir Andrew Pollard and Professor Daniela Ferreira, the group is conducting the research to develop vaccines against antibiotic-resistant pathogens.
+
+### 🔹 Technical Details
+
+- **Human Challenge Trials**: Participants are deliberately infected under controlled conditions to study immune responses to specific pathogens.
+
+- **AI-Driven Data Analysis**: Utilizing artificial intelligence to process large biological datasets, including blood and tissue samples, to identify effective immune responses.
+
+- **Targeted Pathogens**: E. coli, Streptococcus pneumoniae, and Staphylococcus aureus, known for their resistance to antibiotics.
+
+### 🔹 Benchmark Results
+
+No specific benchmark results are provided in the available information.
+
+### 🔹 References
+
+- [Oracle billionaire's institute gives Oxford major grant for AI vaccine research](https://www.ft.com/content/e21af386-2171-4d2d-a4a6-9d52761261ff)
+
+- [Larry Ellison tech institute unveils Oxford university tie-up](https://www.ft.com/content/f949c646-88a3-4c65-9257-98fd6aea0e7b)
+
+- [Oxford launches major new AI vaccine research programme with the Ellison Institute of Technology](https://www.ox.ac.uk/news/2025-09-01-oxford-launches-major-new-ai-vaccine-research-programme-ellison-institute-technology)
+
+- [Ellison’s £118M Gift Fuels AI-Powered Vaccine Research at Oxford](https://inews.zoombangla.com/ellisons-118m-gift-fuels-ai-powered-vaccine-research-at-oxford/)
+
+---  


### PR DESCRIPTION
This pull request adds a news markdown file summarizing Oracle's £118 million grant to Oxford University for AI-driven vaccine research against antibiotic-resistant pathogens.