### PR TITLE
Add OpenAI and Broadcom AI chip partnership news summary

### DIFF
--- a/news/2025-09/openai-broadcom-ai-chip-partnership-2025.md
+++ b/news/2025-09/openai-broadcom-ai-chip-partnership-2025.md
@@ -1,0 +1,27 @@
+# OpenAI Partners with Broadcom to Develop Custom AI Chips
+
+**Source:** Champaign Magazine  
+**Date:** 2025-09-14  
+**URL:** [https://champaignmagazine.com/2025/09/14/ai-by-ai-weekly-top-5-september-8-14-2025/?utm_source=openai](https://champaignmagazine.com/2025/09/14/ai-by-ai-weekly-top-5-september-8-14-2025/?utm_source=openai)
+
+---
+
+OpenAI has partnered with Broadcom to develop custom AI chips, aiming to reduce reliance on NVIDIA and lower operational costs. These chips are expected to launch in 2026 and will power OpenAI's models internally, potentially reshaping AI hardware supply chains.
+
+## Key Details:
+
+- **Partnership Announcement:** OpenAI and Broadcom have co-designed AI accelerators tailored for AI workloads. The first units are expected to ship in 2026, primarily for internal use within OpenAI's data centers. ([arstechnica.com](https://arstechnica.com/ai/2025/09/openai-links-up-with-broadcom-to-produce-its-own-ai-chips/?utm_source=openai))
+
+- **Strategic Significance:** This collaboration signifies OpenAI's move towards greater hardware autonomy, aiming to reduce dependence on third-party GPU providers like NVIDIA. By developing proprietary AI hardware, OpenAI seeks to enhance computational efficiency, lower operational costs, and gain more control over its AI infrastructure. ([arstechnica.com](https://arstechnica.com/ai/2025/09/openai-links-up-with-broadcom-to-produce-its-own-ai-chips/?utm_source=openai))
+
+- **Industry Context:** The AI hardware landscape is evolving, with major companies like Google, Meta, and Amazon investing in custom AI hardware to meet the increasing computational demands of training and running advanced AI models. OpenAI's initiative aligns with this trend, positioning it alongside other tech giants in developing proprietary AI infrastructure. ([arstechnica.com](https://arstechnica.com/ai/2025/09/openai-links-up-with-broadcom-to-produce-its-own-ai-chips/?utm_source=openai))
+
+## References:
+
+- [OpenAI links up with Broadcom to produce its own AI chips](https://arstechnica.com/ai/2025/09/openai-links-up-with-broadcom-to-produce-its-own-ai-chips/)
+
+- [OpenAI to Build its Own AI Chip with Broadcom, Aims to Ship in 2026](https://www.outlookbusiness.com/artificial-intelligence/openai-to-build-its-own-ai-chip-with-broadcom-aims-to-ship-in-2026)
+
+- [OpenAI collaborates with Broadcom to produce an AI chip for internal operations](https://www.livemint.com/technology/tech-news/openai-collaborates-with-broadcom-to-produce-an-ai-chip-for-internal-operations/amp-11757337185820.html)
+
+This development marks a significant step in OpenAI's strategy to enhance its AI infrastructure and reduce dependency on external hardware providers.


### PR DESCRIPTION
This pull request adds a new markdown file summarizing the recent partnership between OpenAI and Broadcom to develop custom AI chips, aimed at reducing reliance on NVIDIA and lowering operational costs. The chips are expected to launch in 2026 and will power OpenAI's models internally.