### PR TITLE
Add article about 2024 Nobel Prize in Chemistry honoring AI-driven protein design

### DIFF
--- a/news/2024-10/nobel-prize-chemistry-ai-protein-design-2024.md
+++ b/news/2024-10/nobel-prize-chemistry-ai-protein-design-2024.md
@@ -1,0 +1,52 @@
+## Nobel Prize in Chemistry Honors AI-Driven Protein Design
+
+**Source:** AP News  
+**Date:** 2024-10-09  
+**URL:** [https://apnews.com/article/56f4d9e90591dfe7d9d840a8c8c9d553](https://apnews.com/article/56f4d9e90591dfe7d9d840a8c8c9d553)  
+**Summary:** The 2024 Nobel Prize in Chemistry was awarded to researchers for pioneering AI-based techniques to decode and design new proteins, revolutionizing medicine and vaccines development.
+
+---
+
+### What Happened
+
+The 2024 Nobel Prize in Chemistry was awarded to David Baker, Demis Hassabis, and John M. Jumper for their groundbreaking work in computational protein design and structure prediction. Baker was recognized for "computational protein design," while Hassabis and Jumper were honored for "protein structure prediction." ([nobelprize.org](https://www.nobelprize.org/prizes/chemistry/2024/press-release/?utm_source=openai))
+
+### Why It Matters
+
+This award highlights the transformative impact of artificial intelligence on biochemistry. The laureates' work enables scientists to design novel proteins and predict their structures with unprecedented accuracy, accelerating the development of new medicines, vaccines, and materials. ([nobelprize.org](https://www.nobelprize.org/prizes/chemistry/2024/press-release/?utm_source=openai))
+
+### Who's Involved
+
+- **David Baker**: Professor at the University of Washington and Howard Hughes Medical Institute, recognized for his contributions to computational protein design.
+
+- **Demis Hassabis**: CEO of Google DeepMind, honored for developing AI models for protein structure prediction.
+
+- **John M. Jumper**: Senior Research Scientist at Google DeepMind, co-recipient for his work on protein structure prediction.
+
+### Technical Details
+
+- **AlphaFold2**: An AI model developed by Hassabis and Jumper that predicts protein structures from amino acid sequences with high accuracy. ([nobelprize.org](https://www.nobelprize.org/prizes/chemistry/2024/press-release/?utm_source=openai))
+
+- **Rosetta Program**: Developed by Baker, this computational tool designs new proteins with specific functions, aiding in drug development and other applications. ([nobelprize.org](https://www.nobelprize.org/prizes/chemistry/2024/press-release/?utm_source=openai))
+
+---
+
+### Benchmark Results
+
+While specific benchmark scores are not provided in the available sources, the development of AlphaFold2 marked a significant advancement in protein structure prediction, achieving near-experimental accuracy in predicting protein structures. ([nobelprize.org](https://www.nobelprize.org/prizes/chemistry/2024/press-release/?utm_source=openai))
+
+---
+
+### References
+
+- [The Nobel Prize in Chemistry 2024 - Press Release](https://www.nobelprize.org/prizes/chemistry/2024/press-release/)
+
+- [AI-driven protein design earns chemistry #NobelPrize2024 | Headline Science - American Chemical Society](https://www.acs.org/pressroom/headline-science/chemistry-nobel-2024.html)
+
+- [Nobel Prize in chemistry honors 3 scientists who used AI to design proteins — life's building blocks | AP News](https://apnews.com/article/56f4d9e90591dfe7d9d840a8c8c9d553)
+
+- [Nobel Prize in chemistry honors 3 scientists who used AI to design proteins — ...  | AP News](https://apnews.com/article/56f4d9e90591dfe7d9d840a8c8c9d553)
+
+- [2024 Nobel Prize in chemistry awarded to scientists who revealed a 'completely new world of protein structures' | Live Science](https://www.livescience.com/chemistry/2024-nobel-prize-in-chemistry-awarded-to-scientists-who-revealed_a_completely_new_world_of_protein-structures)
+
+- [Nobel de chimie 2024 : l'intelligence artificielle encore à l'honneur | Le Monde](https://www.lemonde.fr/sciences/article/2024/10/09/nobel-de-chimie-2024-l-intelligence-artificielle-encore_a_l_honneur_6347492_1650684.html)


### PR DESCRIPTION
This PR adds a new article about the 2024 Nobel Prize in Chemistry awarded for pioneering AI-based techniques to decode and design new proteins, highlighting the transformative impact of AI on medicine and vaccine development.