### PR TITLE
Add Alexa+ news summary for October 2025

### DIFF
--- a/news/2025-10/alexa-plus.md
+++ b/news/2025-10/alexa-plus.md
@@ -1,0 +1,39 @@
+## 📰 Alexa+ - Here's Everything You Need to Know
+
+**Source:** Tom's Guide  
+**Date:** October 10, 2025  
+**URL:** [https://www.tomsguide.com/ai/alexa-release-date-cost-devices-and-all-the-new-ai-features](https://www.tomsguide.com/ai/alexa-release-date-cost-devices-and-all-the-new-ai-features)  
+**Summary:** Amazon has introduced Alexa+, a generative AI upgrade to its voice assistant, enhancing natural interactions, multitasking, and proactive assistance. Built on Amazon's Bedrock with models from Anthropic, Alexa+ is available on Echo Show devices with subscription options.
+
+---
+
+### What Happened
+
+Amazon unveiled Alexa+, a next-generation assistant powered by generative AI, aiming to provide more conversational, smarter, and personalized interactions. This upgrade is available on Echo Show devices, with subscription options for users. ([aboutamazon.com](https://www.aboutamazon.com/news/devices/new-alexa-generative-artificial-intelligence/?utm_source=openai))
+
+### Why It Matters
+
+The introduction of Alexa+ signifies Amazon's commitment to advancing AI capabilities in its voice assistant, enhancing user experience through natural conversations and proactive assistance. This move positions Amazon to better compete in the evolving AI assistant market. ([cnbc.com](https://www.cnbc.com/2025/02/26/amazon-unveils-long-awaited-alexa-revamped-with-ai-features.html?utm_source=openai))
+
+### Who's Involved
+
+- **Amazon:** Developed and launched Alexa+, integrating generative AI to enhance its voice assistant.
+- **Anthropic:** Provided AI models used in Alexa+ to improve conversational abilities. ([cnbc.com](https://www.cnbc.com/2025/02/26/amazon-unveils-long-awaited-alexa-revamped-with-ai-features.html?utm_source=openai))
+
+### Technical Details
+
+- **Platform:** Built on Amazon's Bedrock, utilizing large language models (LLMs) for advanced AI capabilities.
+- **AI Models:** Incorporates models from Anthropic to enhance conversational abilities. ([cnbc.com](https://www.cnbc.com/2025/02/26/amazon-unveils-long-awaited-alexa-revamped-with-ai-features.html?utm_source=openai))
+- **Devices:** Initially available on Echo Show devices, with plans for broader integration. ([aboutamazon.com](https://www.aboutamazon.com/news/devices/new-alexa-generative-artificial-intelligence/?utm_source=openai))
+
+### Benchmark Results
+
+Specific benchmark results for Alexa+ have not been publicly disclosed.
+
+### References
+
+- [Introducing Alexa+, the next generation of Alexa](https://www.aboutamazon.com/news/devices/new-alexa-generative-artificial-intelligence/)
+- [Amazon unveils revamped Alexa with AI free for Prime members](https://www.cnbc.com/2025/02/26/amazon-unveils-long-awaited-alexa-revamped-with-ai-features.html)
+- [Amazon refreshes device lineup for Alexa+ AI, home security](https://www.reuters.com/technology/amazon-refreshes-device-lineup-alexa-ai-home-security-2025-09-30/)
+
+---


### PR DESCRIPTION
This pull request adds a summary markdown file for the Alexa+ news article from October 2025, located in the news/2025-10/ folder.