### PR TITLE
Add news about Cisco P200 chip for AI data center connectivity

### DIFF
--- a/news/2025-10/2025-10-cisco-ai-data-center-chip.md
+++ b/news/2025-10/2025-10-cisco-ai-data-center-chip.md
@@ -1,0 +1,35 @@
+## Cisco Rolls Out Chip Designed to Connect AI Data Centers Over Vast Distances
+
+**Source:** Reuters (original article currently inaccessible)  
+**Date:** October 8, 2025  
+**Summary:** Cisco introduced the P200 chip, a networking component aimed at linking AI data centers globally. It consolidates 92 chips into one, reducing power consumption by 65%. This chip will be key in Cisco's new routers for AI workloads with customers like Microsoft and Alibaba.
+
+---
+
+### What Happened
+
+Cisco Systems unveiled the P200 chip, designed to interconnect AI data centers over vast distances. The chip will power Cisco's new routers tailored for AI workloads, with Microsoft and Alibaba as early customers.
+
+### Why It Matters
+
+AI workloads require connecting data centers up to 1,000 miles apart for large-scale AI training. The P200 chip offers a scalable and energy-efficient solution to this challenge.
+
+### Who's Involved
+
+- Cisco Systems: Developer of the P200 chip and AI workload routers.
+- Microsoft: Initial customer.
+- Alibaba: Initial customer.
+
+### Technical Details
+
+- P200 Chip consolidates 92 chips into one reducing power consumption by 65%.
+- Cisco 8223 Routing System: 51.2 Tbps fixed router powered by P200 chip for AI data center networks.
+
+---
+
+### References
+
+- [Cisco unveils industry's first 51.2T router to power distributed AI networks](https://www.crnasia.com/news/2025/data-center/cisco-unveils-industrys-first-51)
+- [Cisco Launches New Silicon One Chip To ‘Satiate’ Rising AI Data Center Demands](https://www.crn.com/news/networking/2025/cisco-launches-new-silicon-one-chip-to-satiate-rising-ai-data-center-demands)
+- [Cisco Silicon One P200 Deep Buffer Router Chip Data Sheet](https://www.cisco.com/c/en/us/products/collateral/networking/silicon-one/silicon-one-p200-processor-ds.html)
+- [Cisco Sets Benchmark with Industry's Most Scalable, Efficient 51.2T Routing Systems for Distributed AI Workloads](https://newsroom.cisco.com/c/r/newsroom/en/us/a/y2025/m10/cisco-sets-benchmark-with-industrys-most-scalable-efficient-51-2t-routing-systems-for-distributed-ai-workloads.html?source=rss)


### PR DESCRIPTION
This PR adds a news markdown file about Cisco's new P200 chip designed to interconnect AI data centers over vast distances. The chip consolidates 92 chips into one and reduces power consumption by 65%. Key customers include Microsoft and Alibaba.