### PR TITLE
Add news summary for Anthropic expanding partnership with Google for TPU access

### DIFF
--- a/news/2025-10/anthropic-google-tpus.md
+++ b/news/2025-10/anthropic-google-tpus.md
@@ -1,0 +1,42 @@
+## 📰 Anthropic Expands Partnership with Google for AI Chip Access
+
+**Source:** Reuters  
+**Date:** October 23, 2025  
+**URL:** [https://www.reuters.com/technology/anthropic-expand-use-google-clouds-tpu-chips-2025-10-23/](https://www.reuters.com/technology/anthropic-expand-use-google-clouds-tpu-chips-2025-10-23/)  
+**Summary:** Anthropic has significantly expanded its partnership with Google, gaining access to up to one million Tensor Processing Units (TPUs) from Google starting in 2026, enabling training of advanced language models and highlighting increased demand for AI compute resources.
+
+---
+
+### 539 What Happened
+
+Anthropic, an AI safety and research company, has announced a substantial expansion of its partnership with Google Cloud. The agreement grants Anthropic access to up to one million of Google's Tensor Processing Units (TPUs), with over one gigawatt of computing capacity expected to be online by 2026. This collaboration aims to support the development and deployment of Anthropic's Claude AI models. 
+
+### 539 Why It Matters
+
+The partnership underscores the escalating demand for AI computing power, as companies like Anthropic and OpenAI strive to develop increasingly sophisticated models. By leveraging Google's TPUs, Anthropic can enhance the efficiency and scalability of its AI systems, positioning itself as a significant player in the competitive AI market. 
+
+### 539 Who's Involved
+
+- **Anthropic**: An AI safety and research company known for developing the Claude AI models.
+- **Google Cloud**: Google's cloud computing division providing the Tensor Processing Units (TPUs) and additional cloud services.
+
+### 539 Technical Details
+
+- **Models**: Claude AI models developed by Anthropic.
+- **Technology**: Google's Tensor Processing Units (TPUs), specialized hardware accelerators designed for machine learning tasks.
+- **Capacity**: Over one gigawatt of computing power expected to be online by 2026.
+
+---
+
+### 539 Benchmark Results
+
+No specific benchmark results are provided in the available sources.
+
+---
+
+### 517 References
+
+- [Anthropic to use Google's AI chips worth tens of billions to train Claude chatbot](https://www.reuters.com/technology/anthropic-expand-use-google-clouds-tpu-chips-2025-10-23/)
+- [Expanding our use of Google Cloud TPUs and Services](https://www.anthropic.com/news/expanding-our-use-of-google-cloud-tpus-and-services)
+
+---  


### PR DESCRIPTION
This pull request adds a markdown summary of the news article about Anthropic expanding its partnership with Google to access up to one million TPUs for AI model training starting in 2026.