### PR TITLE
Add news summary: OpenAI roadmap for AI research interns (2026) and autonomous AI researchers (2028)

### DIFF
--- a/news/2025-10/openai-roadmap-ai-researchers-2026-2028.md
+++ b/news/2025-10/openai-roadmap-ai-researchers-2026-2028.md
@@ -1,0 +1,31 @@
+## 📰 OpenAI Roadmap Revealed: AI Research Interns by 2026, Full-Blown AGI Researchers by 2028
+
+**Source:** TechRadar  
+**Date:** 2025-10-29  
+**URL:** [https://www.techradar.com/ai-platforms-assistants/chatgpt/openai-roadmap-revealed-ai-research-interns-by-2026-full-blown-agi-researchers-by-2028](https://www.techradar.com/ai-platforms-assistants/chatgpt/openai-roadmap-revealed-ai-research-interns-by-2026-full-blown-agi-researchers-by-2028)  
+**Summary:** OpenAI CEO Sam Altman has unveiled an ambitious roadmap detailing the development of AI capabilities over the coming years. Speaking during a livestream, Altman revealed that by 2026, OpenAI aims for its models to function as AI "research interns"—tools that can help users analyze academic papers, compare findings, clarify complex topics, and even suggest next steps, moving beyond current chatbot capabilities. This AI would be more proactive in assisting tasks but still needs improvements in accuracy and reliability to be truly effective.
+
+Looking further ahead, by March 2028, OpenAI hopes to create an autonomous "AI researcher" capable of independently designing experiments, testing hypotheses, and presenting insights—essentially functioning more like a colleague than a tool. While this isn't full artificial general intelligence (AGI), it marks a dramatic shift in how AI might influence research workflows and the broader job landscape. Altman emphasized that AGI won’t arrive at a single moment but will emerge gradually over years.
+
+Despite confidence in the timeline, the transition from today’s chatbots to reliable, autonomous agents faces significant challenges, including eliminating hallucinations, ensuring transparency, and establishing proper oversight. For OpenAI, achieving actual utility and trustworthiness will be more critical than simply meeting target dates.
+
+---
+
+### 🔹 What Happened
+OpenAI CEO Sam Altman shared a roadmap to develop AI models that act as research interns by 2026 and fully autonomous AI researchers by 2028, marking a transformative shift in AI-assisted scientific workflows.
+
+### 🔹 Why It Matters
+This roadmap signifies OpenAI's commitment to advancing AI capabilities, aiming to revolutionize research processes by introducing AI models that can proactively assist in analyzing academic papers, comparing findings, and suggesting next steps. The vision of autonomous AI researchers by 2028 suggests a future where AI can independently design experiments, test hypotheses, and present insights, potentially reshaping the research landscape and job market.
+
+### 🔹 Who's Involved
+- **Sam Altman**: CEO of OpenAI, leading the initiative and sharing the development roadmap.
+- **OpenAI**: The organization driving the development of advanced AI models with the goal of creating AI research interns by 2026 and autonomous AI researchers by 2028.
+
+### 🔹 Technical Details
+- **AI Research Interns (2026)**: AI models designed to assist users in analyzing academic papers, comparing findings, clarifying complex topics, and suggesting next steps. These models aim to be more proactive in assisting tasks but require improvements in accuracy and reliability to be truly effective.
+- **Autonomous AI Researchers (2028)**: AI models capable of independently designing experiments, testing hypotheses, and presenting insights, functioning more like a colleague than a tool. This represents a significant advancement beyond current AI capabilities.
+
+---
+
+### 🔗 References
+- [OpenAI roadmap revealed: AI research interns by 2026, full-blown AGI researchers by 2028](https://www.techradar.com/ai-platforms-assistants/chatgpt/openai-roadmap-revealed-ai-research-interns-by-2026-full-blown-agi-researchers-by-2028)


### PR DESCRIPTION
This PR adds a new markdown file with a summary of the TechRadar news article revealing OpenAI's roadmap to develop AI research interns by 2026 and autonomous AI researchers by 2028, outlining key details and implications.