### PR TITLE
Add news article markdown for AIML AI Roadmap Generator launch

### DIFF
--- a/news/2025-10/aiml-ai-roadmap-generator-news.md
+++ b/news/2025-10/aiml-ai-roadmap-generator-news.md
@@ -1,0 +1,37 @@
+## 📰 AIML Launches AI Roadmap Generator to Support Australian Businesses
+
+**Source:** adelaide.edu.au  
+**Date:** 2025-10-10  
+**URL:** [https://www.adelaide.edu.au/aiml/news/list/2025/10/10/aiml-developed-ai-roadmap-generator-makes-it-easier-for-companies-to-embark-on](https://www.adelaide.edu.au/aiml/news/list/2025/10/10/aiml-developed-ai-roadmap-generator-makes-it-easier-for-companies-to-embark-on)  
+**Summary:** The Australian Institute for Machine Learning (AIML) introduced the AI Roadmap Generator tool to assist Australian businesses in integrating artificial intelligence (AI) into their operations.
+
+---
+
+### 🔹 What Happened
+
+On October 8, 2025, AIML officially launched the AI Roadmap Generator, a tool designed to help businesses across Australia incorporate AI into their operations. The launch event featured Michael Brown MP, South Australia's Assistant Minister for AI, Digital Economy, Defence, and Space Industries. ([adelaide.edu.au](https://www.adelaide.edu.au/aiml/news/list/2025/10/10/aiml-developed-ai-roadmap-generator-makes-it-easier-for-companies-to-embark-on?utm_source=openai))
+
+### 🔹 Why It Matters
+
+The AI Roadmap Generator aims to make AI adoption more accessible for Australian businesses, particularly small and medium enterprises (SMEs). By providing tailored AI strategies, the tool seeks to enhance operational efficiency, reduce costs, and boost customer satisfaction. This initiative aligns with AIML's broader goal of fostering AI integration across various industries in Australia. ([adelaide.edu.au](https://www.adelaide.edu.au/aiml/news/list/2025/10/10/aiml-developed-ai-roadmap-generator-makes-it-easier-for-companies-to-embark-on?utm_source=openai))
+
+### 🔹 Who's Involved
+
+- **Australian Institute for Machine Learning (AIML):** Developed and launched the AI Roadmap Generator.
+- **Michael Brown MP:** South Australia's Assistant Minister for AI, Digital Economy, Defence, and Space Industries, who attended the launch event.
+- **Jonathon Read:** AIML Engineering Manager and one of the developers of the Roadmap Generator.
+- **Richard Pinter:** AIML Engineer who collaborated on the development of the tool.
+
+### 🔹 Technical Details
+
+- **AI Roadmap Generator:** A business analysis assistant that uses inputs about a company's operations to create a structured AI strategy. It employs AIML's proprietary 8-lens discovery framework to assess an organization's goals, challenges, and data readiness, generating a report with tailored AI initiative recommendations, business impact analysis, phased timelines, compliance guidance, and curated educational resources. ([adelaide.edu.au](https://www.adelaide.edu.au/aiml/news/list/2025/10/10/aiml-developed-ai-roadmap-generator-makes-it-easier-for-companies-to-embark-on?utm_source=openai))
+
+### 🔹 Benchmark Results
+
+No specific benchmark results were provided in the available information.
+
+### 🔹 References
+
+- [AIML-developed AI Roadmap Generator makes it easier for companies to embark on their AI journey](https://www.adelaide.edu.au/aiml/news/list/2025/10/10/aiml-developed-ai-roadmap-generator-makes-it-easier-for-companies-to-embark-on)
+
+---  


### PR DESCRIPTION
This pull request adds a markdown news article about the launch of the AI Roadmap Generator by the Australian Institute for Machine Learning (AIML) to support AI adoption in Australian businesses.