### PR TITLE
Add news article: Gartner AI jobs disruption 2025 report

### DIFF
--- a/news/2025-11/gartner-ai-jobs-disruption.md
+++ b/news/2025-11/gartner-ai-jobs-disruption.md
@@ -1,0 +1,47 @@
+# 📰 Gartner: AI will disrupt millions of jobs but not cause apocalypse
+
+**Source:** IT Pro  
+**Date:** 2025-11-11  
+**URL:** https://www.itpro.com/business/gartner-says-ai-wont-create-a-jobs-apocalypse-but-it-will-cause-chaos-as-millions-are-forced-to-upskill?utm_source=openai
+
+---
+
+### Summary
+
+Gartner's report predicts AI will transform around 32 million jobs annually starting in 2028, emphasizing massive upskilling without an overall employment collapse.
+
+---
+
+### What Happened
+
+Gartner, a leading research and advisory company, released a report forecasting that by 2028, approximately 32 million jobs will undergo significant transformation each year due to the integration of artificial intelligence (AI). This shift is expected to lead to substantial upskilling requirements for the workforce, rather than causing widespread job losses.
+
+---
+
+### Why It Matters
+
+This projection highlights the profound impact AI is anticipated to have on the global labor market. While automation and AI technologies are often associated with job displacement, Gartner's analysis suggests that the focus should be on reskilling and adapting the workforce to new roles and responsibilities.
+
+---
+
+### Who's Involved
+
+- **Gartner, Inc.:** A global research and advisory firm specializing in technology and business insights.
+- **Helen Poitevin:** Distinguished Vice President Analyst at Gartner, who presented the findings at the Gartner IT Symposium/Xpo in Barcelona.
+
+---
+
+### Technical Details
+
+The report outlines four potential scenarios for human-AI collaboration in work:
+
+1. Humans want AI to do the work, yet work is not significantly transformed - AI handles tasks humans cannot perform effectively, reducing worker numbers.
+2. Humans want AI to do the work, and work is transformed with fewer workers than before - autonomous business model with leaner workforce.
+3. Humans want to do the work with AI, and work remains mostly the same but with AI integration - AI enhances human performance.
+4. Humans want to do the work with AI, and work is transformed allowing tackling more complex challenges - applied in personalized medicine.
+
+---
+
+### References
+
+- URL: https://www.gartner.com/en/newsroom/press-releases/2025-11-11-gartner-says-leaders-must-create-four-scenarios-for-human-artificial-intelligence-collaboration-at-work


### PR DESCRIPTION
This PR adds a new news article markdown summarizing the Gartner report on AI job disruption and upskilling, dated 2025-11-11.