### PR TITLE
Add news summary: OpenAI $38B multi-year AWS cloud deal

### DIFF
--- a/news/2025-11/openai-aws-38b-deal.md
+++ b/news/2025-11/openai-aws-38b-deal.md
@@ -1,0 +1,46 @@
+## 📰 OpenAI Secures $38 Billion Multi-Year AWS Deal for Cloud Infrastructure
+
+**Source:** Jason Wade  
+**Date:** November 4, 2025  
+**URL:** [https://www.jasonwade.com/today-s-ai-tech-news-november-4-2025?utm_source=openai](https://www.jasonwade.com/today-s-ai-tech-news-november-4-2025?utm_source=openai)  
+**Summary:** OpenAI has finalized a $38 billion multi-year contract with Amazon Web Services (AWS) for cloud infrastructure, ending its exclusive reliance on Microsoft Azure and preparing for next-generation AI model training.
+
+---
+
+### 🔹 What Happened
+
+OpenAI and Amazon Web Services (AWS) have entered into a seven-year, $38 billion strategic partnership. This agreement grants OpenAI immediate access to AWS's advanced cloud infrastructure, including hundreds of thousands of NVIDIA GPUs, to support the training and deployment of its AI models. The partnership signifies a shift from OpenAI's previous exclusive reliance on Microsoft Azure for cloud services.
+
+### 🔹 Why It Matters
+
+This collaboration is pivotal for OpenAI as it seeks to scale its AI capabilities. The substantial investment in AWS's infrastructure will enable OpenAI to meet the growing computational demands of its AI workloads, facilitating the development of more advanced models and services. Additionally, the move to diversify cloud service providers reduces OpenAI's dependency on a single vendor, enhancing operational flexibility and resilience.
+
+### 🔹 Who's Involved
+
+- **OpenAI:** The AI research organization focused on developing advanced artificial intelligence technologies.
+- **Amazon Web Services (AWS):** Amazon's cloud computing division providing a wide range of cloud services, including computing power, storage, and databases.
+- **NVIDIA:** The semiconductor company supplying GPUs essential for AI model training and inference.
+
+### 🔹 Technical Details
+
+- **AWS EC2 UltraServers:** AWS's high-performance computing instances designed to handle demanding workloads, including AI model training.
+- **NVIDIA GPUs (GB200s and GB300s):** Advanced graphics processing units utilized for accelerating AI computations.
+- **Scalability:** The agreement allows OpenAI to scale its compute capacity to tens of millions of CPUs, accommodating the increasing complexity of AI models.
+
+---
+
+### 🔹 Benchmark Results
+
+*No specific benchmark results were provided in the available sources.*
+
+---
+
+### 🔹 References
+
+- [OpenAI and AWS Announce Multi-Year Strategic Partnership](https://openai.com/index/aws-and-openai-partnership/)
+- [OpenAI and Amazon sign $38 billion deal for AI computing power](https://apnews.com/article/071e752773dee5713c8b1a10039d08aa)
+- [OpenAI and Amazon ink $38B cloud computing deal](https://techcrunch.com/2025/11/03/openai-and-amazon-ink-38b-cloud-computing-deal/)
+
+---
+
+**Note:** The information provided is based on the latest available sources as of November 18, 2025.


### PR DESCRIPTION
This pull request adds a new markdown summary file about OpenAI's $38 billion multi-year contract with AWS for cloud infrastructure, highlighting the major details and technical aspects of the deal.