### PR TITLE
Add news article: Yann LeCun departs Meta to launch AI startup

### DIFF
--- a/news/2025-11/yann-lecun-departs-meta-launches-ai-startup.md
+++ b/news/2025-11/yann-lecun-departs-meta-launches-ai-startup.md
@@ -1,0 +1,8 @@
+# Meta's Chief AI Scientist Yann LeCun Announces Departure to Launch New AI Startup
+
+**Source:** AP News  
+**Date:** 2025-11-19  
+**URL:** [https://apnews.com/article/313159512bb9961f324e0c93bccf4cf5?utm_source=openai](https://apnews.com/article/313159512bb9961f324e0c93bccf4cf5?utm_source=openai)
+
+## Summary
+Yann LeCun, Meta's Chief AI Scientist, is leaving the company to start a new AI-focused startup. This new venture aims to develop advanced artificial intelligence systems capable of understanding the physical world, performing reasoning, and planning complex actions. LeCun's departure marks a significant shift as he embarks on pioneering work beyond what Meta currently pursues.


### PR DESCRIPTION
This PR adds a markdown news article about Yann LeCun's departure from Meta to start a new AI company focused on advanced AI capabilities.